### PR TITLE
Allow manual trigger for build-image workflow

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- add `workflow_dispatch` to enable manual runs for the build image workflow

## Testing
- `shellcheck entrypoint.sh setup_universal.sh`
- `yamllint .github/workflows/build-image.yml` *(fails: too many spaces inside brackets, wrong indentation, trailing spaces)*

------
https://chatgpt.com/codex/tasks/task_e_687b85db57688320ab1e4d3e1ada7e5a