### PR TITLE
Fix workflow triggers with paths-ignore

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -3,11 +3,11 @@ name: Build Python Image
 on:
   push:
     branches: [ "main" ]
-    paths:
-      - 'Dockerfile'
-      - 'setup_universal.sh'
-      - 'entrypoint.sh'
-      - '.github/workflows/build-image.yml'
+    paths-ignore:
+      - 'README.md'
+      - 'LICENSES/**'
+      - '*.md'
+      - 'docs/**'
   pull_request:
     branches: [ "main" ]
   workflow_dispatch:


### PR DESCRIPTION
- Switch from paths to paths-ignore approach
- Ignore README.md, LICENSES/**, *.md, and docs/** files
- This prevents documentation-only changes from triggering Docker builds
- Removes bootstrap issue where workflow changes trigger builds
- Code and Docker configuration changes will still trigger builds