### PR TITLE
Reorder Python versions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ You can also use version-specific tags:
 docker pull ghcr.io/s2005/codex-python:3.12
 
 # Other Python versions
-docker pull ghcr.io/s2005/codex-python:3.11
 docker pull ghcr.io/s2005/codex-python:3.10
+docker pull ghcr.io/s2005/codex-python:3.11
 docker pull ghcr.io/s2005/codex-python:3.13
 ```
 


### PR DESCRIPTION
- Arrange Python versions in ascending order: 3.10, 3.11, 3.13
- Improves readability and follows semantic versioning order
- No functional changes, documentation update only