### PR TITLE
Enable Docker image push for manual workflow triggers

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -66,7 +66,7 @@ jobs:
       uses: docker/build-push-action@v6
       with:
         platforms: linux/amd64,linux/arm64
-        push: ${{ github.event_name == 'push' }}
+        push: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
         tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
         build-args: |
           PYTHON_VERSION=${{ env.IMAGE_TAG }}
@@ -75,7 +75,7 @@ jobs:
     
     - name: Generate artifact attestation
       uses: actions/attest-build-provenance@v2
-      if: ${{ github.event_name == 'push' }}
+      if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
       with:
         push-to-registry: true
         subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}


### PR DESCRIPTION
## Overview
This PR enables Docker image pushing when the "Build Python Image" workflow is triggered manually via `workflow_dispatch`.

## Problem
Currently, when manually triggering the workflow with a specific Python version (e.g., 3.13), the Docker image is built successfully but not pushed to the GitHub Container Registry. This means users cannot pull the manually built images.

## Solution
Modified the workflow conditions to include `workflow_dispatch` events:

### Changes Made
1. **Build and push step** (line 69):
   - **Before:** `push: ${{ github.event_name == 'push' }}`
   - **After:** `push: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}`

2. **Artifact attestation step** (line 78):
   - **Before:** `if: ${{ github.event_name == 'push' }}`
   - **After:** `if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}`

## Impact
- ✅ Manual workflow triggers now push images to `ghcr.io/s2005/codex-python:X.XX`
- ✅ Automatic triggers on push to main still work as before
- ✅ Artifact attestations are generated for both trigger types
- ✅ No breaking changes to existing functionality

## Testing
After merging, you can:
1. Manually trigger the workflow with Python 3.13
2. Pull the image with: `docker pull ghcr.io/s2005/codex-python:3.13`

## Files Changed
- `.github/workflows/build-image.yml` - Updated push and attestation conditions